### PR TITLE
Fix Registration links that were incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The agendas for the calls are tracked in the Agenda Archive in this repository. 
 ### Who Can Attend
 Anyone who wants to contribute to Zcash protocol development and to share news on Zcash node projects.
 
-Register here: [15:00 UTC](https://us06web.zoom.us/webinar/register/WN_Vk7WMz9sRkiIr_hqH_x3LA) / [21:00 UTC](https://zfnd-org.zoom.us/webinar/register/WN_Y4yuMoPuS-u87aBhfpMHhg#/registration)
+Register here: [15:00 UTC](https://zfnd-org.zoom.us/webinar/register/WN_42A2bMIiSziGGNG3MTEcqQ) / [21:00 UTC](https://zfnd-org.zoom.us/webinar/register/WN_Y4yuMoPuS-u87aBhfpMHhg)
 
 ### Who Manages the Meetings
 The Zcash Foundation facilitates and records the meetings.


### PR DESCRIPTION
The link referred to a seminar that had a different owner and  was not longer valid. I changed them to the ones on the Zfnd web page. https://zfnd.org/arborist-calls/